### PR TITLE
2018 highlights, applyToSpeak, typos

### DIFF
--- a/data/faq.md
+++ b/data/faq.md
@@ -2,7 +2,7 @@
 
 ### Dates and location
 
-GDG DevFest South Africa will take place on the 1st of December in [The Capital on The Park,](https://goo.gl/maps/Fhdes8rccQ62) Sandton, Gauteng South Africa.
+GDG DevFest South Africa will take place on the 30th of November in [UCT GSB Academic Conference Centre,](https://goo.gl/maps/HBpwkqeTuWDmgpxo8) Cape Town, South Africa.
 
 ### Stay Informed
 

--- a/data/resources.json
+++ b/data/resources.json
@@ -226,7 +226,7 @@
     "blocks": [
       {
         "title": "Organizer",
-        "description": "<a href='https://www.meetup.com/Google-Developer-Group-Cape-Town-Meetup/' target='_blank'>GDG Cape Town</a> with support of 2 GDGs from all around South Africa is proud organizer of DevFest South Africa",
+        "description": "<a href='https://www.meetup.com/Google-Developer-Group-Cape-Town-Meetup/' target='_blank'>GDG Cape Town</a> and <a href='https://www.meetup.com/GDGJohannesburg/' target='_blank'>GDG Johannesburg</a> are proud organizes of DevFest South Africa",
         "callToAction": {
           "label": "Open team page",
           "link": "/team"

--- a/data/resources.json
+++ b/data/resources.json
@@ -165,11 +165,11 @@
     }
   },
   "galleryBlock": {
-    "title": "#dfua16 highlights",
-    "description": "This year's festival built lots of excitement. Check out photos from featured talks, hands-on learning sessions, and after-hours fun.",
+    "title": "DevFest 18 Highlights",
+    "description": "Last year's festival built lots of excitement. Check out photos from featured talks, hands-on learning sessions, and after-hours fun.",
     "callToAction": {
       "label": "See all photos",
-      "link": "https://goo.gl/photos/H8s3CtPexCzkLqSt9"
+      "link": "https://photos.app.goo.gl/EkYhWwwrd4gsdwQw7"
     }
   },
   "mapBlock": {
@@ -193,7 +193,7 @@
     "toast": "Successfully subscribed!"
   },
   "team": {
-    "description": "Google is known all around the world. Everyone is 'googling', checking on 'maps' and communicating in 'gmail'. For simple users, they are services that just works, but not for us. Developers see much more: APIs, scalability issues, complex technology stacks. And that is what GDG is about.<br><br> [GDG Cape Town](https://www.meetup.com/Google-Developer-Group-Cape-Town-Meetup/) and [GDG Johannesburg](https://www.meetup.com/GDGJohannesburg/) are open and volunteer geek communities which create exciting projects and share experiences about Google technologies with a passion.<br><br> Our goal is to organize space to connect the best industry experts with South African audience to boost development of IT."
+    "description": "Google is known all around the world. Everyone is 'googling', checking on 'maps' and communicating in 'gmail'. For simple users, they are services that just works, but not for us. Developers see much more: APIs, scalability issues, complex technology stacks. And that is what GDG is about.<br><br> [GDG Cape Town](https://www.meetup.com/Google-Developer-Group-Cape-Town-Meetup/) and [GDG Johannesburg](https://www.meetup.com/GDGJohannesburg/) are open and volunteer geek communities which create exciting projects and share experiences about Google technologies with a passion.<br><br> Our goal is to organise space to connect the best industry experts with South African audience to boost development of IT."
   },
   "schedule": {
     "saveSessionsSignedOut": "Sign in to save sessions"
@@ -225,8 +225,8 @@
     "image": "/images/team.jpg",
     "blocks": [
       {
-        "title": "Organizer",
-        "description": "<a href='https://www.meetup.com/Google-Developer-Group-Cape-Town-Meetup/' target='_blank'>GDG Cape Town</a> and <a href='https://www.meetup.com/GDGJohannesburg/' target='_blank'>GDG Johannesburg</a> are proud organizes of DevFest South Africa",
+        "title": "Organiser",
+        "description": "<a href='https://www.meetup.com/Google-Developer-Group-Cape-Town-Meetup/' target='_blank'>GDG Cape Town</a> and <a href='https://www.meetup.com/GDGJohannesburg/' target='_blank'>GDG Johannesburg</a> are proud organisers of DevFest South Africa",
         "callToAction": {
           "label": "Open team page",
           "link": "/team"

--- a/data/resources.json
+++ b/data/resources.json
@@ -169,7 +169,7 @@
     "description": "Last year's festival built lots of excitement. Check out photos from featured talks, hands-on learning sessions, and after-hours fun.",
     "callToAction": {
       "label": "See all photos",
-      "link": "https://photos.app.goo.gl/EkYhWwwrd4gsdwQw7"
+      "link": "https://photos.google.com/share/AF1QipOVKByadcUKC5M8xYjLJD7FXxObFK3K5rC10LaKADp_0mg9q4rPW81yAev4HZxLPQ?key=VFJyMzFnWGQ0Z0g4ZjRsSEI5WUo1OUV5aXQzSjhB"
     }
   },
   "mapBlock": {

--- a/data/resources.json
+++ b/data/resources.json
@@ -193,7 +193,7 @@
     "toast": "Successfully subscribed!"
   },
   "team": {
-    "description": "Google is known all around the world. Everyone is 'googling', checking on 'maps' and communicating in 'gmail'. For simple users, they are services that just works, but not for us. Developers see much more: APIs, scalability issues, complex technology stacks. And that is what GDG is about.<br><br> [Google Developers Group (GDG) South Africa](https://www.meetup.com/Google-Developer-Group-Cape-Town-Meetup/) - is open and volunteer geek community who create exciting projects and share experience about Google technologies with a passion.<br><br> Our goal is to organize space to connect the best industry experts with South African audience to boost development of IT."
+    "description": "Google is known all around the world. Everyone is 'googling', checking on 'maps' and communicating in 'gmail'. For simple users, they are services that just works, but not for us. Developers see much more: APIs, scalability issues, complex technology stacks. And that is what GDG is about.<br><br> [GDG Cape Town](https://www.meetup.com/Google-Developer-Group-Cape-Town-Meetup/) and [GDG Johannesburg](https://www.meetup.com/GDGJohannesburg/) are open and volunteer geek communities which create exciting projects and share experiences about Google technologies with a passion.<br><br> Our goal is to organize space to connect the best industry experts with South African audience to boost development of IT."
   },
   "schedule": {
     "saveSessionsSignedOut": "Sign in to save sessions"

--- a/src/pages/home-page.html
+++ b/src/pages/home-page.html
@@ -9,7 +9,7 @@
 <link rel="import" href="../elements/partners-block.html">
 <!-- <link rel="import" href="../elements/featured-videos.html"> -->
 <link rel="import" href="../elements/subscribe-block.html">
-<!-- <link rel="import" href="../elements/gallery-block.html"> -->
+<link rel="import" href="../elements/gallery-block.html"> 
 <link rel="import" href="../elements/map-block.html">
 <link rel="import" href="../elements/about-organizer-block.html">
 <link rel="import" href="../mixins/scroll-functions.html">
@@ -187,10 +187,10 @@
       </div>
     </hero-block>
     <about-block></about-block>
-    <speakers-block></speakers-block>
+    <!-- <speakers-block></speakers-block> -->
     <subscribe-block></subscribe-block>
     <tickets-block></tickets-block>
-    <!-- <gallery-block></gallery-block> -->
+    <gallery-block></gallery-block>
     <about-organizer-block></about-organizer-block>
     <!-- <featured-videos></featured-videos> -->
     <latest-posts-block></latest-posts-block>

--- a/src/pages/home-page.html
+++ b/src/pages/home-page.html
@@ -167,14 +167,14 @@
             </paper-button>
           </a>
           
-         <!--  <a href="http://bit.ly/devfestza-2018" rel="noopener noreferrer" target="_blank">
+         <a href="https://bit.ly/devfest-south-africa-2019-speak" rel="noopener noreferrer" target="_blank">
             <paper-button
               primary invert
             >
               <iron-icon icon="hoverboard:movie"></iron-icon>
               {$ applyToSpeak $}
             </paper-button>
-          </a> -->
+          </a> 
         </div>
 
         <div class="scroll-down" on-tap="_scrollNextBlock">


### PR DESCRIPTION
- add gallery and link to GDG JHB 2018 Highlights Google Photos album
- add applyToSpeak button back on top of home page. Should be removed c4p is closed. 
- cosmetics and typos