### PR TITLE
Change # sessions, CoC, previous speakers.

### DIFF
--- a/data/coc.md
+++ b/data/coc.md
@@ -37,6 +37,3 @@ To report an incident look for a staff member by badge/attire or contact our inc
 {% for contact in codeOfConductBlock.contacts %}
 - {$ contact $}{% endfor %}
 
-#### Anonymous report
-
-You can make an anonymous report [here]({$ codeOfConductBlock.form $}). We can't follow up with you directly, but we will fully investigate it and take whatever action is necessary to prevent a recurrence.

--- a/data/package-lock.json
+++ b/data/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}

--- a/data/resources.json
+++ b/data/resources.json
@@ -101,7 +101,7 @@
       },
       "sessions": {
         "label": "Sessions",
-        "number": "20"
+        "number": "25"
       },
       "tracks": {
         "label": "Tracks",

--- a/src/pages/speakers-page.html
+++ b/src/pages/speakers-page.html
@@ -267,7 +267,7 @@
       </template>
     </div>
 
-    <previous-speakers-block></previous-speakers-block>
+    <!-- <previous-speakers-block></previous-speakers-block> -->
 
     <footer-block></footer-block>
 


### PR DESCRIPTION
Regarding anon incident reporting, the link didn't point to anywhere.
Rather removed it. Shortly before the event we will publish email and
phone numbers of dedicated organisers.